### PR TITLE
Add navigation with CV and portfolio pages

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,14 @@
 
 Sitio estático de portafolio construido con Preact y Tailwind CSS usando Vite.
 
+## Estructura del sitio
+
+- **Inicio** (`src/pages/Home.jsx`): breve presentación.
+- **CV** (`src/pages/CV.jsx`): sección para tus datos profesionales.
+- **Portafolio** (`src/pages/Portfolio.jsx`): listado de proyectos con imagen, descripción y enlace.
+
+Cada archivo incluye comentarios `{/* ... */}` que indican dónde reemplazar la información con tus datos reales. Las imágenes de ejemplo (`public/profile.svg` y `public/project-ejemplo.svg`) son archivos SVG en blanco para que los sustituyas por tus propios recursos.
+
 ## Dependencias de código abierto
 
 - **Preact** (MIT): biblioteca de UI ligera para construir componentes reutilizables.

--- a/public/profile.svg
+++ b/public/profile.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="200" height="200"></svg>

--- a/public/project-ejemplo.svg
+++ b/public/project-ejemplo.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="300" height="200"></svg>

--- a/src/app.jsx
+++ b/src/app.jsx
@@ -1,17 +1,26 @@
+import { useState, useEffect } from 'preact/hooks';
+import Nav from './components/Nav.jsx';
+import Home from './pages/Home.jsx';
+import CV from './pages/CV.jsx';
+import Portfolio from './pages/Portfolio.jsx';
 
 export default function App() {
+  const [page, setPage] = useState(() => window.location.hash.slice(1) || 'home');
+
+  useEffect(() => {
+    const onHashChange = () => setPage(window.location.hash.slice(1) || 'home');
+    window.addEventListener('hashchange', onHashChange);
+    return () => window.removeEventListener('hashchange', onHashChange);
+  }, []);
+
   return (
-    <main class="min-h-screen flex flex-col items-center justify-center p-8 gap-8 text-center">
-      <h1 class="text-4xl font-bold">Mi Portafolio</h1>
-      <p class="max-w-prose">
-        Bienvenido a mi portafolio. Aquí encontrarás información sobre mis habilidades y experiencia profesional.
-      </p>
-      <a
-        href="#"
-        class="px-4 py-2 bg-blue-600 text-white rounded hover:bg-blue-700"
-      >
-        Ver CV
-      </a>
-    </main>
+    <div class="min-h-screen flex flex-col">
+      <Nav />
+      <main class="flex-1">
+        {page === 'home' && <Home />}
+        {page === 'cv' && <CV />}
+        {page === 'portafolio' && <Portfolio />}
+      </main>
+    </div>
   );
 }

--- a/src/components/Nav.jsx
+++ b/src/components/Nav.jsx
@@ -1,0 +1,19 @@
+import { h } from 'preact';
+
+export default function Nav() {
+  return (
+    <nav class="bg-gray-800 text-white p-4">
+      <ul class="flex justify-center gap-4">
+        <li>
+          <a href="#home" class="hover:underline">Inicio</a>
+        </li>
+        <li>
+          <a href="#cv" class="hover:underline">CV</a>
+        </li>
+        <li>
+          <a href="#portafolio" class="hover:underline">Portafolio</a>
+        </li>
+      </ul>
+    </nav>
+  );
+}

--- a/src/pages/CV.jsx
+++ b/src/pages/CV.jsx
@@ -1,0 +1,42 @@
+export default function CV() {
+  return (
+    <section class="p-8 max-w-3xl mx-auto">
+      <h2 class="text-3xl font-bold mb-4">Currículum Vitae</h2>
+      <div class="flex flex-col items-center gap-4">
+        <img src="/profile.svg" alt="Foto de perfil" class="w-32 h-32 rounded-full" />
+        <h3 class="text-2xl font-semibold">Juan Pérez</h3>
+        <p class="text-center">
+          {/* Reemplaza con una breve descripción personal */}
+          Desarrollador web con pasión por crear experiencias intuitivas.
+        </p>
+      </div>
+      <section class="mt-8">
+        <h4 class="text-xl font-semibold">Experiencia</h4>
+        <ul class="list-disc ml-5">
+          <li>
+            {/* Reemplaza con tu experiencia laboral */}
+            Empresa Ficticia — Desarrollador Frontend (2022 - Actualidad)
+          </li>
+        </ul>
+      </section>
+      <section class="mt-4">
+        <h4 class="text-xl font-semibold">Educación</h4>
+        <ul class="list-disc ml-5">
+          <li>
+            {/* Reemplaza con tu formación académica */}
+            Universidad de Ejemplo — Ingeniería Informática (2018 - 2022)
+          </li>
+        </ul>
+      </section>
+      <section class="mt-4">
+        <h4 class="text-xl font-semibold">Habilidades</h4>
+        <ul class="list-disc ml-5">
+          {/* Agrega o modifica las habilidades según tu perfil */}
+          <li>JavaScript</li>
+          <li>React</li>
+          <li>Tailwind CSS</li>
+        </ul>
+      </section>
+    </section>
+  );
+}

--- a/src/pages/Home.jsx
+++ b/src/pages/Home.jsx
@@ -1,0 +1,11 @@
+export default function Home() {
+  return (
+    <section class="flex flex-col items-center justify-center p-8 text-center gap-4">
+      <h1 class="text-4xl font-bold">Mi Portafolio</h1>
+      <p class="max-w-prose">
+        {/* Reemplaza con una breve introducción sobre ti */}
+        Bienvenido a mi portafolio. Aquí encontrarás información sobre mis habilidades y proyectos.
+      </p>
+    </section>
+  );
+}

--- a/src/pages/Portfolio.jsx
+++ b/src/pages/Portfolio.jsx
@@ -1,0 +1,26 @@
+export default function Portfolio() {
+  return (
+    <section class="p-8 max-w-5xl mx-auto">
+      <h2 class="text-3xl font-bold mb-4">Portafolio</h2>
+      <div class="grid md:grid-cols-2 gap-8">
+        <article class="border rounded p-4">
+          <img src="/project-ejemplo.svg" alt="Proyecto de ejemplo" class="mb-4" />
+          <h3 class="text-2xl font-semibold">Proyecto de Ejemplo</h3>
+          <p class="mb-2">
+            {/* Reemplaza con la descripción de tu proyecto */}
+            Breve descripción del proyecto realizado.
+          </p>
+          <a
+            href="#"
+            class="text-blue-600 hover:underline"
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            {/* Reemplaza con el enlace a tu proyecto */}
+            Ver proyecto
+          </a>
+        </article>
+      </div>
+    </section>
+  );
+}


### PR DESCRIPTION
## Summary
- add hash-based navigation bar with links to Home, CV, and Portfolio
- create CV and Portfolio pages with placeholder content and images
- document site structure and placeholders in README

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build` *(fails: Cannot find module @rollup/rollup-linux-x64-gnu)*

------
https://chatgpt.com/codex/tasks/task_b_68a9fd38f17483298ec5fecf075d9d90