### PR TITLE
Add privacy policy route for Cosechas Mega

### DIFF
--- a/src/app.jsx
+++ b/src/app.jsx
@@ -3,15 +3,48 @@ import Nav from './components/Nav.jsx';
 import Home from './pages/Home.jsx';
 import CV from './pages/CV.jsx';
 import Portfolio from './pages/Portfolio.jsx';
+import CosechasMegaPrivacy from './pages/CosechasMegaPrivacy.jsx';
+
+const getCurrentPage = () => {
+  const hash = window.location.hash.slice(1);
+  if (hash) {
+    return hash;
+  }
+
+  const path = window.location.pathname.replace(/^\/+/, '');
+  return path || 'home';
+};
 
 export default function App() {
-  const [page, setPage] = useState(() => window.location.hash.slice(1) || 'home');
+  const [page, setPage] = useState(getCurrentPage);
 
   useEffect(() => {
-    const onHashChange = () => setPage(window.location.hash.slice(1) || 'home');
-    window.addEventListener('hashchange', onHashChange);
-    return () => window.removeEventListener('hashchange', onHashChange);
+    const onRouteChange = () => setPage(getCurrentPage());
+    window.addEventListener('hashchange', onRouteChange);
+    window.addEventListener('popstate', onRouteChange);
+    return () => {
+      window.removeEventListener('hashchange', onRouteChange);
+      window.removeEventListener('popstate', onRouteChange);
+    };
   }, []);
+
+  useEffect(() => {
+    if (page === 'cosechasmega/privacidad') {
+      const desiredPath = '/cosechasmega/privacidad';
+      const currentUrl = `${window.location.pathname}${window.location.hash}`;
+      if (currentUrl !== desiredPath) {
+        window.history.replaceState(null, '', desiredPath);
+      }
+    } else {
+      const desiredHash = `#${page}`;
+      if (window.location.pathname !== '/') {
+        window.history.replaceState(null, '', '/');
+      }
+      if (window.location.hash !== desiredHash) {
+        window.location.hash = desiredHash;
+      }
+    }
+  }, [page]);
 
   return (
     <div class="min-h-screen flex flex-col">
@@ -20,6 +53,7 @@ export default function App() {
         {page === 'home' && <Home />}
         {page === 'cv' && <CV />}
         {page === 'portafolio' && <Portfolio />}
+        {page === 'cosechasmega/privacidad' && <CosechasMegaPrivacy />}
       </main>
     </div>
   );

--- a/src/components/Nav.jsx
+++ b/src/components/Nav.jsx
@@ -1,6 +1,12 @@
 import { h } from 'preact';
 
 export default function Nav() {
+  const handlePrivacyClick = (event) => {
+    event.preventDefault();
+    window.history.pushState(null, '', '/cosechasmega/privacidad');
+    window.dispatchEvent(new PopStateEvent('popstate'));
+  };
+
   return (
     <nav class="bg-gray-800 text-white p-4">
       <ul class="flex justify-center gap-4">
@@ -12,6 +18,11 @@ export default function Nav() {
         </li>
         <li>
           <a href="#portafolio" class="hover:underline">Portafolio</a>
+        </li>
+        <li>
+          <a href="/cosechasmega/privacidad" class="hover:underline" onClick={handlePrivacyClick}>
+            Privacidad
+          </a>
         </li>
       </ul>
     </nav>

--- a/src/pages/CosechasMegaPrivacy.jsx
+++ b/src/pages/CosechasMegaPrivacy.jsx
@@ -1,0 +1,34 @@
+import { h } from 'preact';
+
+export default function CosechasMegaPrivacy() {
+  return (
+    <section class="max-w-3xl mx-auto px-4 py-12 space-y-6">
+      <header class="space-y-2">
+        <h1 class="text-3xl font-bold text-gray-900">Política de Privacidad de Cosechas Mega</h1>
+        <p class="text-gray-600">
+          Esta página describe cómo Cosechas Mega protege la información de las personas usuarias de la aplicación.
+        </p>
+      </header>
+
+      <article class="space-y-4 text-gray-700 leading-relaxed">
+        <p>
+          Cosechas Mega ha sido diseñada para ofrecer una experiencia sencilla y segura. No recopilamos, almacenamos ni
+          compartimos información personal identificable de quienes usan la aplicación. Tampoco utilizamos servicios de
+          analítica, publicidad ni herramientas de terceros que rastreen a las personas usuarias.
+        </p>
+
+        <p>
+          Todos los datos que se muestran dentro de la aplicación permanecen en el dispositivo y únicamente se utilizan
+          para prestar las funciones básicas del producto. Si en el futuro llegamos a implementar nuevas
+          características que requieran recopilar información adicional, actualizaremos esta política y notificaremos a
+          las personas usuarias con antelación.
+        </p>
+
+        <p>
+          Si tienes preguntas sobre esta política de privacidad, puedes escribirnos a
+          <a class="text-indigo-600 font-medium" href="mailto:contacto@cosechasmega.com"> contacto@cosechasmega.com</a>.
+        </p>
+      </article>
+    </section>
+  );
+}


### PR DESCRIPTION
## Summary
- add a dedicated privacy policy view for the Cosechas Mega application
- extend the navigation and routing logic to support the new cosechasmega/privacidad path

## Testing
- npm run build *(fails: Cannot find module '@rollup/rollup-linux-x64-gnu')*

------
https://chatgpt.com/codex/tasks/task_b_68d815b6f2dc83299b1067157d665365