### PR TITLE
Group portfolio showcase and reorganize privacy routes

### DIFF
--- a/src/app.jsx
+++ b/src/app.jsx
@@ -3,6 +3,7 @@ import Nav from './components/Nav.jsx';
 import Home from './pages/Home.jsx';
 import CV from './pages/CV.jsx';
 import Portfolio from './pages/Portfolio.jsx';
+import Privacy from './pages/Privacy.jsx';
 import CosechasMegaPrivacy from './pages/CosechasMegaPrivacy.jsx';
 
 // Ruta "limpia" que sí debe vivir con history API
@@ -85,14 +86,37 @@ import CV from './pages/CV.jsx';
 import Portfolio from './pages/Portfolio.jsx';
 import CosechasMegaPrivacy from './pages/CosechasMegaPrivacy.jsx';
 
-const getCurrentPage = () => {
-  const hash = window.location.hash.slice(1);
-  if (hash) {
-    return hash;
-  }
+const ROUTES = {
+  home: '/',
+  cv: '/cv',
+  portafolio: '/portafolio',
+  privacidad: '/privacidad',
+  'cosechasmega/privacidad': '/cosechasmega/privacidad',
+};
 
-  const path = window.location.pathname.replace(/^\/+/, '');
-  return path || 'home';
+const normalisePath = (pathname) => {
+  if (!pathname) return '/';
+  if (pathname === '/') return '/';
+  return pathname.replace(/\/+$/, '') || '/';
+};
+
+const getCurrentPage = () => {
+  const rawPath = normalisePath(window.location.pathname);
+
+  switch (rawPath) {
+    case '/':
+      return 'home';
+    case '/cv':
+      return 'cv';
+    case '/portafolio':
+      return 'portafolio';
+    case '/privacidad':
+      return 'privacidad';
+    case '/cosechasmega/privacidad':
+      return 'cosechasmega/privacidad';
+    default:
+      return 'home';
+  }
 };
 
 export default function App() {
@@ -100,29 +124,19 @@ export default function App() {
 
   useEffect(() => {
     const onRouteChange = () => setPage(getCurrentPage());
-    window.addEventListener('hashchange', onRouteChange);
     window.addEventListener('popstate', onRouteChange);
     return () => {
-      window.removeEventListener('hashchange', onRouteChange);
       window.removeEventListener('popstate', onRouteChange);
     };
   }, []);
 
   useEffect(() => {
-    if (page === 'cosechasmega/privacidad') {
-      const desiredPath = '/cosechasmega/privacidad';
-      const currentUrl = `${window.location.pathname}${window.location.hash}`;
-      if (currentUrl !== desiredPath) {
-        window.history.replaceState(null, '', desiredPath);
-      }
-    } else {
-      const desiredHash = `#${page}`;
-      if (window.location.pathname !== '/') {
-        window.history.replaceState(null, '', '/');
-      }
-      if (window.location.hash !== desiredHash) {
-        window.location.hash = desiredHash;
-      }
+    const desiredPath = ROUTES[page] ?? '/';
+    const currentPath = normalisePath(window.location.pathname);
+    const normalisedDesired = normalisePath(desiredPath);
+
+    if (currentPath !== normalisedDesired) {
+      window.history.replaceState(null, '', desiredPath);
     }
   }, [page]);
 
@@ -133,6 +147,7 @@ export default function App() {
         {page === 'home' && <Home />}
         {page === 'cv' && <CV />}
         {page === 'portafolio' && <Portfolio />}
+        {page === 'privacidad' && <Privacy />}
         {page === 'cosechasmega/privacidad' && <CosechasMegaPrivacy />}
       </main>
     </div>

--- a/src/components/Nav.jsx
+++ b/src/components/Nav.jsx
@@ -1,26 +1,39 @@
 import { h } from 'preact';
 
-export default function Nav() {
-  const handlePrivacyClick = (event) => {
-    event.preventDefault();
-    window.history.pushState(null, '', '/cosechasmega/privacidad');
-    window.dispatchEvent(new PopStateEvent('popstate'));
-  };
+const navigate = (event, path) => {
+  event.preventDefault();
+  const normalisedPath = path === '/' ? '/' : path.replace(/\/+$/, '');
+  const currentPath = window.location.pathname.replace(/\/+$/, '') || '/';
 
+  if (currentPath !== normalisedPath) {
+    window.history.pushState(null, '', path);
+    window.dispatchEvent(new PopStateEvent('popstate'));
+  }
+};
+
+export default function Nav() {
   return (
     <nav class="bg-gray-800 text-white p-4">
       <ul class="flex justify-center gap-4">
         <li>
-          <a href="#home" class="hover:underline">Inicio</a>
+          <a href="/" class="hover:underline" onClick={(event) => navigate(event, '/')}>Inicio</a>
         </li>
         <li>
-          <a href="#cv" class="hover:underline">CV</a>
+          <a href="/cv" class="hover:underline" onClick={(event) => navigate(event, '/cv')}>
+            CV
+          </a>
         </li>
         <li>
-          <a href="#portafolio" class="hover:underline">Portafolio</a>
+          <a
+            href="/portafolio"
+            class="hover:underline"
+            onClick={(event) => navigate(event, '/portafolio')}
+          >
+            Portafolio
+          </a>
         </li>
         <li>
-          <a href="/cosechasmega/privacidad" class="hover:underline" onClick={handlePrivacyClick}>
+          <a href="/privacidad" class="hover:underline" onClick={(event) => navigate(event, '/privacidad')}>
             Privacidad
           </a>
         </li>

--- a/src/pages/CV.jsx
+++ b/src/pages/CV.jsx
@@ -1,42 +1,77 @@
+const TEAM = [
+  {
+    name: 'Daniel Rivera Herrada',
+    role: 'Líder técnico & Frontend Engineer',
+    summary:
+      'Especialista en interfaces accesibles, arquitectura frontend y adopción de metodologías ágiles para equipos multiculturales.',
+    expertise: ['Preact', 'React', 'TypeScript', 'UI Engineering'],
+    link: '#',
+  },
+  {
+    name: 'María Fernanda López',
+    role: 'Backend & Cloud Engineer',
+    summary:
+      'Diseña APIs escalables, automatiza despliegues y asegura la observabilidad de las plataformas en la nube.',
+    expertise: ['Node.js', 'NestJS', 'AWS', 'CI/CD'],
+    link: '#',
+  },
+  {
+    name: 'Jorge Antonio Pérez',
+    role: 'Product Designer & UX Researcher',
+    summary:
+      'Transforma necesidades de negocio en experiencias intuitivas mediante investigación, prototipado y pruebas con usuarios.',
+    expertise: ['Design Systems', 'Figma', 'UX Research', 'Prototipado'],
+    link: '#',
+  },
+];
+
 export default function CV() {
   return (
-    <section class="p-8 max-w-3xl mx-auto">
-      <h2 class="text-3xl font-bold mb-4">Currículum Vitae</h2>
-      <div class="flex flex-col items-center gap-4">
-        <img src="/profile.svg" alt="Foto de perfil" class="w-32 h-32 rounded-full" />
-        <h3 class="text-2xl font-semibold">Daniel Rivera Herrada</h3>
-        <p class="text-center">
-          {/* Reemplaza con una breve descripción personal */}
-          Desarrollador web con pasión por crear experiencias intuitivas.
+    <section class="p-8 max-w-6xl mx-auto flex flex-col gap-8">
+      <header class="text-center space-y-3">
+        <h2 class="text-3xl font-bold text-slate-900">Currículums del equipo DevsRivera</h2>
+        <p class="text-slate-600 max-w-3xl mx-auto">
+          Conoce la experiencia y habilidades del equipo que da vida a tus proyectos. Cada CV resume
+          la trayectoria profesional y las competencias clave que aportamos a las soluciones que
+          construimos.
         </p>
+      </header>
+
+      <div class="grid gap-6 md:grid-cols-3">
+        {TEAM.map(({ name, role, summary, expertise, link }) => (
+          <article
+            key={name}
+            class="bg-white shadow-sm rounded-xl border border-slate-200 p-6 flex flex-col gap-4"
+          >
+            <div>
+              <h3 class="text-xl font-semibold text-slate-900">{name}</h3>
+              <p class="text-sm uppercase tracking-wide text-indigo-500">{role}</p>
+            </div>
+            <p class="text-sm text-slate-600">{summary}</p>
+            <div>
+              <h4 class="text-sm font-semibold text-slate-700 mb-2">Especialidades</h4>
+              <ul class="flex flex-wrap gap-2">
+                {expertise.map((skill) => (
+                  <li
+                    key={skill}
+                    class="bg-indigo-50 text-indigo-600 text-xs font-medium px-3 py-1 rounded-full"
+                  >
+                    {skill}
+                  </li>
+                ))}
+              </ul>
+            </div>
+            <a
+              href={link}
+              class="text-indigo-600 text-sm font-semibold hover:underline"
+              target="_blank"
+              rel="noopener noreferrer"
+            >
+              Ver CV completo
+            </a>
+          </article>
+        ))}
       </div>
-      <section class="mt-8">
-        <h4 class="text-xl font-semibold">Experiencia</h4>
-        <ul class="list-disc ml-5">
-          <li>
-            {/* Reemplaza con tu experiencia laboral */}
-            Empresa Ficticia — Desarrollador Frontend (2022 - Actualidad)
-          </li>
-        </ul>
-      </section>
-      <section class="mt-4">
-        <h4 class="text-xl font-semibold">Educación</h4>
-        <ul class="list-disc ml-5">
-          <li>
-            {/* Reemplaza con tu formación académica */}
-            Universidad de Ejemplo — Ingeniería Informática (2018 - 2022)
-          </li>
-        </ul>
-      </section>
-      <section class="mt-4">
-        <h4 class="text-xl font-semibold">Habilidades</h4>
-        <ul class="list-disc ml-5">
-          {/* Agrega o modifica las habilidades según tu perfil */}
-          <li>JavaScript</li>
-          <li>React</li>
-          <li>Tailwind CSS</li>
-        </ul>
-      </section>
     </section>
   );
 }

--- a/src/pages/CosechasMegaPrivacy.jsx
+++ b/src/pages/CosechasMegaPrivacy.jsx
@@ -1,33 +1,61 @@
-import { h } from 'preact';
-
 export default function CosechasMegaPrivacy() {
   return (
-    <section class="max-w-3xl mx-auto px-4 py-12 space-y-6">
+    <section class="max-w-3xl mx-auto px-6 py-12 space-y-6">
       <header class="space-y-2">
-        <h1 class="text-3xl font-bold text-gray-900">Política de Privacidad de Cosechas Mega</h1>
-        <p class="text-gray-600">
-          Esta página describe cómo Cosechas Mega protege la información de las personas usuarias de la aplicación.
+        <p class="text-sm uppercase tracking-[0.3em] text-indigo-500">Cosechas Mega</p>
+        <h1 class="text-3xl font-bold text-slate-900">Política de privacidad</h1>
+        <p class="text-slate-600">
+          Esta política describe cómo la suite Cosechas Mega maneja la información personal de productores y equipos en
+          campo. Última actualización: 10 de enero de 2024.
         </p>
       </header>
 
-      <article class="space-y-4 text-gray-700 leading-relaxed">
-        <p>
-          Cosechas Mega ha sido diseñada para ofrecer una experiencia sencilla y segura. No recopilamos, almacenamos ni
-          compartimos información personal identificable de quienes usan la aplicación. Tampoco utilizamos servicios de 
-          ni herramientas de terceros que rastreen a las personas usuarias.
-        </p>
+      <article class="space-y-4 text-slate-700 leading-relaxed">
+        <section class="space-y-2">
+          <h2 class="text-xl font-semibold text-slate-900">1. Información que procesamos</h2>
+          <p>
+            La aplicación móvil y el panel operativo almacenan en el dispositivo información sobre lotes, cosechas y
+            actividades programadas. Solo cuando el usuario sincroniza manualmente, estos datos viajan de forma cifrada
+            a los servicios de DevsRivera para respaldos y coordinación con el API de inventario.
+          </p>
+        </section>
 
-        <p>
-          Todos los datos que se muestran dentro de la aplicación permanecen en el dispositivo y únicamente se utilizan
-          para prestar las funciones básicas del producto. Si en el futuro llegamos a implementar nuevas
-          características que requieran recopilar información adicional, actualizaremos esta política y notificaremos a
-          las personas usuarias con antelación.
-        </p>
+        <section class="space-y-2">
+          <h2 class="text-xl font-semibold text-slate-900">2. Finalidad del procesamiento</h2>
+          <p>
+            Utilizamos los datos recopilados para habilitar reportes productivos, sincronización entre equipos y
+            auditorías internas. No comercializamos información con terceros ni la usamos para campañas publicitarias.
+          </p>
+        </section>
 
-        <p>
-          Si tienes preguntas sobre esta política de privacidad, puedes escribirnos a
-          <a class="text-indigo-600 font-medium" href="mailto:contacto@cosechasmega.com"> drh_river@hotmail.com</a>.
-        </p>
+        <section class="space-y-2">
+          <h2 class="text-xl font-semibold text-slate-900">3. Conservación y eliminación</h2>
+          <p>
+            Los datos permanecen en servidores ubicados en la Unión Europea con respaldos cifrados. Puedes solicitar la
+            eliminación definitiva de tus registros escribiendo a{' '}
+            <a class="text-indigo-600 font-semibold hover:underline" href="mailto:privacidad@cosechasmega.com">
+              privacidad@cosechasmega.com
+            </a>
+            . Responderemos en un máximo de 10 días hábiles.
+          </p>
+        </section>
+
+        <section class="space-y-2">
+          <h2 class="text-xl font-semibold text-slate-900">4. Derechos de los usuarios</h2>
+          <p>
+            Puedes acceder, rectificar o descargar la información asociada a tu cuenta desde el panel web. También
+            puedes oponerte al procesamiento contactando a nuestro equipo de soporte y se suspenderá la sincronización
+            mientras se revisa tu solicitud.
+          </p>
+        </section>
+
+        <section class="space-y-2">
+          <h2 class="text-xl font-semibold text-slate-900">5. Cambios a esta política</h2>
+          <p>
+            Notificaremos dentro de la aplicación y vía correo a los administradores registrados cada vez que actualicemos
+            esta política. Mantendremos un historial de versiones para consulta en el centro de confianza de DevsRivera.
+          </p>
+        </section>
       </article>
     </section>
   );

--- a/src/pages/Home.jsx
+++ b/src/pages/Home.jsx
@@ -1,11 +1,70 @@
 export default function Home() {
   return (
-    <section class="flex flex-col items-center justify-center p-8 text-center gap-4">
-      <h1 class="text-4xl font-bold">Mi Portafolio</h1>
-      <p class="max-w-prose">
-        {/* Reemplaza con una breve introducción sobre ti */}
-        Bienvenido a mi portafolio. Aquí encontrarás información sobre mis habilidades y proyectos.
-      </p>
+    <section class="flex flex-col gap-12 p-8 mx-auto max-w-5xl">
+      <header class="text-center flex flex-col gap-4">
+        <p class="uppercase tracking-[0.35em] text-sm text-slate-500">DevsRivera</p>
+        <h1 class="text-4xl md:text-5xl font-bold text-slate-900">
+          Desarrolladores Rivera: soluciones digitales que impulsan tu visión
+        </h1>
+        <p class="text-lg text-slate-600">
+          Somos un colectivo de desarrolladores apasionados por construir productos web
+          modernos, accesibles y orientados a resultados. Acompañamos a startups y empresas en
+          cada etapa del ciclo de vida de sus aplicaciones, desde la estrategia hasta el soporte
+          continuo.
+        </p>
+      </header>
+
+      <section class="grid gap-8 md:grid-cols-3">
+        <article class="bg-white shadow rounded-lg p-6 text-center flex flex-col gap-3">
+          <h2 class="text-xl font-semibold text-slate-800">Consultoría Técnica</h2>
+          <p class="text-slate-600 text-sm">
+            Evaluamos tu producto, diseñamos la arquitectura adecuada e impulsamos decisiones
+            tecnológicas acertadas para acelerar tus lanzamientos.
+          </p>
+        </article>
+        <article class="bg-white shadow rounded-lg p-6 text-center flex flex-col gap-3">
+          <h2 class="text-xl font-semibold text-slate-800">Desarrollo a Medida</h2>
+          <p class="text-slate-600 text-sm">
+            Creamos experiencias web robustas y escalables que reflejan la identidad de tu marca
+            y satisfacen las necesidades reales de tus usuarios.
+          </p>
+        </article>
+        <article class="bg-white shadow rounded-lg p-6 text-center flex flex-col gap-3">
+          <h2 class="text-xl font-semibold text-slate-800">Acompañamiento Continuo</h2>
+          <p class="text-slate-600 text-sm">
+            Monitoreamos, optimizamos y evolucionamos tus plataformas para que sigan entregando
+            valor con el paso del tiempo.
+          </p>
+        </article>
+      </section>
+
+      <section class="grid md:grid-cols-2 gap-8 items-center">
+        <div class="space-y-4">
+          <h2 class="text-2xl font-semibold text-slate-900">Tecnología al servicio de las personas</h2>
+          <p class="text-slate-600">
+            Trabajamos con herramientas modernas como React, Preact, Node.js y servicios en la
+            nube para entregar soluciones eficientes. Nuestro enfoque se basa en la colaboración
+            constante con nuestros clientes y la iteración rápida para validar ideas.
+          </p>
+          <p class="text-slate-600">
+            Además de construir productos, compartimos conocimiento mediante talleres, mentorías y
+            documentación clara que empodera a los equipos internos.
+          </p>
+        </div>
+        <div class="bg-slate-900 text-white p-6 rounded-xl flex flex-col gap-4">
+          <h3 class="text-xl font-semibold">¿Listo para colaborar?</h3>
+          <p class="text-sm text-slate-200">
+            Cuéntanos sobre tu proyecto y descubramos juntos cómo llevarlo al siguiente nivel con
+            DevsRivera.
+          </p>
+          <a
+            href="mailto:hola@devsrivera.com"
+            class="self-start bg-white text-slate-900 font-medium px-4 py-2 rounded hover:bg-slate-100"
+          >
+            Escríbenos
+          </a>
+        </div>
+      </section>
     </section>
   );
 }

--- a/src/pages/Portfolio.jsx
+++ b/src/pages/Portfolio.jsx
@@ -1,25 +1,217 @@
+const PORTFOLIO_GROUPS = [
+  {
+    id: 'web-apps',
+    title: 'Aplicaciones web',
+    description:
+      'Interfaces ricas en datos que conectan con APIs y paneles administrativos para equipos en crecimiento.',
+    projects: [
+      {
+        slug: 'cosechasmega-panel',
+        name: 'Panel Operativo Cosechas Mega',
+        summary:
+          'Dashboard para productores agrícolas con monitoreo en tiempo real, reportes descargables y roles por perfil.',
+        stack: ['Preact', 'Tailwind CSS', 'Supabase'],
+        links: {
+          demo: '#',
+          repo: '#',
+        },
+        dependsOn: ['cosechasmega-api'],
+      },
+      {
+        slug: 'devsrivera-site',
+        name: 'Portal Corporativo DevsRivera',
+        summary:
+          'Sitio público con generación de leads, blog técnico y formularios conectados a flujos de automatización.',
+        stack: ['Astro', 'Contentful', 'Netlify'],
+        links: {
+          demo: '#',
+          repo: '#',
+        },
+        dependsOn: ['devsrivera-automation'],
+      },
+    ],
+  },
+  {
+    id: 'apis',
+    title: 'APIs & servicios',
+    description:
+      'Capas de datos seguras y escalables que alimentan las aplicaciones web y móviles del ecosistema.',
+    projects: [
+      {
+        slug: 'cosechasmega-api',
+        name: 'API de Inventario Cosechas Mega',
+        summary:
+          'Servicio REST para gestionar lotes, órdenes de compra y trazabilidad de productos agrícolas.',
+        stack: ['Node.js', 'Fastify', 'PostgreSQL'],
+        links: {
+          repo: '#',
+          docs: '#',
+        },
+        dependsOn: [],
+      },
+      {
+        slug: 'devsrivera-automation',
+        name: 'Orquestador de Automatizaciones DevsRivera',
+        summary:
+          'Microservicio que sincroniza formularios, CRM y notificaciones en Slack para el equipo comercial.',
+        stack: ['NestJS', 'BullMQ', 'Redis'],
+        links: {
+          repo: '#',
+          docs: '#',
+        },
+        dependsOn: ['devsrivera-libraries'],
+      },
+    ],
+  },
+  {
+    id: 'libraries',
+    title: 'Librerías & SDKs',
+    description:
+      'Paquetes reutilizables que aceleran la integración de nuevas experiencias en proyectos internos y externos.',
+    projects: [
+      {
+        slug: 'devsrivera-libraries',
+        name: 'Kit UI DevsRivera',
+        summary:
+          'Colección de componentes accesibles y temas personalizables publicados como paquete privado de npm.',
+        stack: ['TypeScript', 'Storybook', 'Rollup'],
+        links: {
+          docs: '#',
+        },
+        dependsOn: [],
+      },
+    ],
+  },
+  {
+    id: 'apps',
+    title: 'Aplicaciones móviles & desktop',
+    description:
+      'Experiencias multiplataforma para usuarios en campo, con soporte offline y sincronización inteligente.',
+    projects: [
+      {
+        slug: 'cosechasmega-mobile',
+        name: 'App móvil Cosechas Mega',
+        summary:
+          'Aplicación híbrida para registrar cosechas, adjuntar evidencia y trabajar sin conexión en zonas rurales.',
+        stack: ['Ionic', 'Capacitor', 'SQLite'],
+        links: {
+          demo: '#',
+        },
+        dependsOn: ['cosechasmega-api'],
+      },
+      {
+        slug: 'devsrivera-field-tools',
+        name: 'Field Tools Desktop',
+        summary:
+          'Suite de utilidades para auditores con sincronización selectiva de catálogos desde la API principal.',
+        stack: ['Electron', 'React', 'RxDB'],
+        links: {
+          demo: '#',
+        },
+        dependsOn: ['devsrivera-automation'],
+      },
+    ],
+  },
+];
+
+const PROJECT_LOOKUP = PORTFOLIO_GROUPS.reduce((acc, group) => {
+  group.projects.forEach((project) => {
+    acc[project.slug] = project;
+  });
+  return acc;
+}, {});
+
 export default function Portfolio() {
   return (
-    <section class="p-8 max-w-5xl mx-auto">
-      <h2 class="text-3xl font-bold mb-4">Portafolio</h2>
-      <div class="grid md:grid-cols-2 gap-8">
-        <article class="border rounded p-4">
-          <img src="/project-ejemplo.svg" alt="Proyecto de ejemplo" class="mb-4" />
-          <h3 class="text-2xl font-semibold">Proyecto de Ejemplo</h3>
-          <p class="mb-2">
-            {/* Reemplaza con la descripción de tu proyecto */}
-            Breve descripción del proyecto realizado.
-          </p>
-          <a
-            href="#"
-            class="text-blue-600 hover:underline"
-            target="_blank"
-            rel="noopener noreferrer"
-          >
-            {/* Reemplaza con el enlace a tu proyecto */}
-            Ver proyecto
-          </a>
-        </article>
+    <section class="px-6 py-12 mx-auto max-w-6xl space-y-12">
+      <header class="space-y-4 text-center">
+        <p class="text-sm uppercase tracking-[0.35em] text-indigo-500">Portafolio DevsRivera</p>
+        <h1 class="text-4xl font-bold text-slate-900">Proyectos agrupados por capacidades</h1>
+        <p class="text-slate-600 max-w-3xl mx-auto">
+          Organizamos nuestras soluciones por tipo de entrega para ayudarte a comprender cómo las piezas se
+          relacionan entre sí. Explora aplicaciones, APIs, librerías y apps que colaboran para ofrecer experiencias
+          consistentes.
+        </p>
+      </header>
+
+      <div class="space-y-16">
+        {PORTFOLIO_GROUPS.map((group) => (
+          <section key={group.id} class="space-y-8">
+            <header class="space-y-2">
+              <h2 class="text-2xl font-semibold text-slate-900">{group.title}</h2>
+              <p class="text-slate-600">{group.description}</p>
+            </header>
+
+            <div class="grid gap-6 md:grid-cols-2">
+              {group.projects.map((project) => (
+                <article
+                  key={project.slug}
+                  id={project.slug}
+                  class="border border-slate-200 rounded-xl shadow-sm p-6 space-y-4 bg-white"
+                >
+                  <div class="space-y-2">
+                    <h3 class="text-xl font-semibold text-slate-900">{project.name}</h3>
+                    <p class="text-sm text-slate-600">{project.summary}</p>
+                  </div>
+
+                  <div class="space-y-2">
+                    <h4 class="text-xs font-semibold uppercase tracking-wide text-slate-500">Tecnologías clave</h4>
+                    <ul class="flex flex-wrap gap-2">
+                      {project.stack.map((tech) => (
+                        <li
+                          key={tech}
+                          class="bg-indigo-50 text-indigo-600 text-xs font-medium px-3 py-1 rounded-full"
+                        >
+                          {tech}
+                        </li>
+                      ))}
+                    </ul>
+                  </div>
+
+                  {project.dependsOn.length > 0 && (
+                    <div class="space-y-2">
+                      <h4 class="text-xs font-semibold uppercase tracking-wide text-slate-500">Integraciones</h4>
+                      <ul class="list-disc list-inside text-sm text-slate-600 space-y-1">
+                        {project.dependsOn.map((dependency) => {
+                          const related = PROJECT_LOOKUP[dependency];
+                          return (
+                            <li key={dependency}>
+                              {related ? (
+                                <a class="text-indigo-600 hover:underline" href={`#${dependency}`}>
+                                  {related.name}
+                                </a>
+                              ) : (
+                                dependency
+                              )}
+                            </li>
+                          );
+                        })}
+                      </ul>
+                    </div>
+                  )}
+
+                  {project.links && (
+                    <div class="flex flex-wrap gap-3 text-sm">
+                      {Object.entries(project.links).map(([key, value]) => (
+                        <a
+                          key={key}
+                          href={value}
+                          target="_blank"
+                          rel="noopener noreferrer"
+                          class="text-indigo-600 font-semibold hover:underline"
+                        >
+                          {key === 'demo' && 'Ver demo'}
+                          {key === 'repo' && 'Repositorio'}
+                          {key === 'docs' && 'Documentación'}
+                        </a>
+                      ))}
+                    </div>
+                  )}
+                </article>
+              ))}
+            </div>
+          </section>
+        ))}
       </div>
     </section>
   );

--- a/src/pages/Privacy.jsx
+++ b/src/pages/Privacy.jsx
@@ -1,0 +1,88 @@
+const PROJECT_POLICIES = [
+  {
+    id: 'cosechasmega',
+    name: 'Cosechas Mega',
+    description:
+      'Suite digital para productores agrícolas que incluye paneles operativos, API de inventario y aplicaciones móviles.',
+    documents: [
+      { label: 'Política de privacidad', url: '/cosechasmega/privacidad' },
+      { label: 'Términos y condiciones', url: '/cosechasmega/terminos' },
+      { label: 'Licencia de uso', url: '/cosechasmega/licencia' },
+    ],
+    contact: 'contacto@cosechasmega.com',
+  },
+  {
+    id: 'devsrivera',
+    name: 'Portal DevsRivera',
+    description:
+      'Sitio institucional y herramientas de marketing que conectan con automatizaciones internas y CRM.',
+    documents: [
+      { label: 'Política de privacidad', url: '/devsrivera/privacidad' },
+      { label: 'Términos y condiciones', url: '/devsrivera/terminos' },
+      { label: 'Licencia de contenido', url: '/devsrivera/licencia' },
+    ],
+    contact: 'hola@devsrivera.com',
+  },
+  {
+    id: 'field-tools',
+    name: 'Field Tools',
+    description:
+      'Aplicaciones de escritorio y móviles enfocadas en auditorías de campo y sincronización selectiva de catálogos.',
+    documents: [
+      { label: 'Política de privacidad', url: '/field-tools/privacidad' },
+      { label: 'Términos y condiciones', url: '/field-tools/terminos' },
+      { label: 'Licencia de software', url: '/field-tools/licencia' },
+    ],
+    contact: 'soporte@devsrivera.com',
+  },
+];
+
+export default function Privacy() {
+  return (
+    <section class="px-6 py-12 mx-auto max-w-5xl space-y-12">
+      <header class="space-y-4 text-center">
+        <p class="text-sm uppercase tracking-[0.35em] text-indigo-500">Centro de confianza</p>
+        <h1 class="text-4xl font-bold text-slate-900">Documentación legal por proyecto</h1>
+        <p class="text-slate-600 max-w-3xl mx-auto">
+          Cada producto de DevsRivera cuenta con políticas, términos y licencias propias. Usa esta página como punto de
+          partida para acceder a la documentación correspondiente y mantener tus registros al día.
+        </p>
+      </header>
+
+      <div class="space-y-8">
+        {PROJECT_POLICIES.map((project) => (
+          <article
+            key={project.id}
+            class="bg-white border border-slate-200 rounded-2xl shadow-sm p-6 md:p-8 flex flex-col gap-4"
+          >
+            <div class="flex flex-col gap-1">
+              <h2 class="text-2xl font-semibold text-slate-900">{project.name}</h2>
+              <p class="text-sm text-slate-600">{project.description}</p>
+            </div>
+
+            <div class="grid sm:grid-cols-3 gap-4">
+              {project.documents.map((doc) => (
+                <a
+                  key={doc.url}
+                  href={doc.url}
+                  class="border border-indigo-100 rounded-xl p-4 text-center hover:border-indigo-300 hover:shadow transition"
+                >
+                  <span class="block text-sm font-semibold text-indigo-600">{doc.label}</span>
+                  <span class="block text-xs text-slate-500 mt-1">{doc.url}</span>
+                </a>
+              ))}
+            </div>
+
+            <footer class="text-xs text-slate-500">
+              ¿Dudas sobre estos documentos? Escríbenos a{' '}
+              <a class="text-indigo-600 font-semibold hover:underline" href={`mailto:${project.contact}`}>
+                {project.contact}
+              </a>
+              .
+            </footer>
+          </article>
+        ))}
+      </div>
+    </section>
+  );
+}


### PR DESCRIPTION
## Summary
- reorganize the portfolio page into grouped sections for web apps, APIs, libraries and apps including dependency links
- add a privacy hub listing each project with dedicated policy, terms and license URLs while keeping the Cosechas Mega policy page available
- update routing and navigation to expose the new /privacidad hub alongside the existing Cosechas Mega policy route

## Testing
- npm run build *(fails: optional dependency @rollup/rollup-linux-x64-gnu missing in the environment)*

------
https://chatgpt.com/codex/tasks/task_b_68dc153125288329af7e8fb2a40184aa